### PR TITLE
feat: SNS Encryption via KMS & Support for Multiple Components

### DIFF
--- a/API.md
+++ b/API.md
@@ -85,6 +85,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-image-pipeline.ImagePipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#cdk-image-pipeline.ImagePipeline.property.imageRecipeComponents">imageRecipeComponents</a></code> | <code>aws-cdk-lib.aws_imagebuilder.CfnImageRecipe.ComponentConfigurationProperty[]</code> | *No description.* |
 
 ---
 
@@ -97,6 +98,16 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `imageRecipeComponents`<sup>Required</sup> <a name="imageRecipeComponents" id="cdk-image-pipeline.ImagePipeline.property.imageRecipeComponents"></a>
+
+```typescript
+public readonly imageRecipeComponents: ComponentConfigurationProperty[];
+```
+
+- *Type:* aws-cdk-lib.aws_imagebuilder.CfnImageRecipe.ComponentConfigurationProperty[]
 
 ---
 
@@ -117,8 +128,9 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.componentDocPath">componentDocPath</a></code> | <code>string</code> | Relative path to the Image Builder component document. |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.componentName">componentName</a></code> | <code>string</code> | Name of the Component. |
+| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.componentDocuments">componentDocuments</a></code> | <code>string[]</code> | Relative path to Image Builder component documents. |
+| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.componentNames">componentNames</a></code> | <code>string[]</code> | Names of the Component Documents. |
+| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.componentVersions">componentVersions</a></code> | <code>string[]</code> | Versions for each component document. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.imageRecipe">imageRecipe</a></code> | <code>string</code> | Name of the Image Recipe. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.infraConfigName">infraConfigName</a></code> | <code>string</code> | Name of the Infrastructure Configuration for Image Builder. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.kmsKeyAlias">kmsKeyAlias</a></code> | <code>string</code> | KMS Key used to encrypt the SNS topic. |
@@ -134,27 +146,39 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 
 ---
 
-##### `componentDocPath`<sup>Required</sup> <a name="componentDocPath" id="cdk-image-pipeline.ImagePipelineProps.property.componentDocPath"></a>
+##### `componentDocuments`<sup>Required</sup> <a name="componentDocuments" id="cdk-image-pipeline.ImagePipelineProps.property.componentDocuments"></a>
 
 ```typescript
-public readonly componentDocPath: string;
+public readonly componentDocuments: string[];
 ```
 
-- *Type:* string
+- *Type:* string[]
 
-Relative path to the Image Builder component document.
+Relative path to Image Builder component documents.
 
 ---
 
-##### `componentName`<sup>Required</sup> <a name="componentName" id="cdk-image-pipeline.ImagePipelineProps.property.componentName"></a>
+##### `componentNames`<sup>Required</sup> <a name="componentNames" id="cdk-image-pipeline.ImagePipelineProps.property.componentNames"></a>
 
 ```typescript
-public readonly componentName: string;
+public readonly componentNames: string[];
 ```
 
-- *Type:* string
+- *Type:* string[]
 
-Name of the Component.
+Names of the Component Documents.
+
+---
+
+##### `componentVersions`<sup>Required</sup> <a name="componentVersions" id="cdk-image-pipeline.ImagePipelineProps.property.componentVersions"></a>
+
+```typescript
+public readonly componentVersions: string[];
+```
+
+- *Type:* string[]
+
+Versions for each component document.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -121,6 +121,7 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.componentName">componentName</a></code> | <code>string</code> | Name of the Component. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.imageRecipe">imageRecipe</a></code> | <code>string</code> | Name of the Image Recipe. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.infraConfigName">infraConfigName</a></code> | <code>string</code> | Name of the Infrastructure Configuration for Image Builder. |
+| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.kmsKeyAlias">kmsKeyAlias</a></code> | <code>string</code> | KMS Key used to encrypt the SNS topic. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.parentImage">parentImage</a></code> | <code>string</code> | The source (parent) image that the image recipe uses as its base environment. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.pipelineName">pipelineName</a></code> | <code>string</code> | Name of the Image Pipeline. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.profileName">profileName</a></code> | <code>string</code> | Name of the instance profile that will be associated with the Instance Configuration. |
@@ -178,6 +179,20 @@ public readonly infraConfigName: string;
 - *Type:* string
 
 Name of the Infrastructure Configuration for Image Builder.
+
+---
+
+##### `kmsKeyAlias`<sup>Required</sup> <a name="kmsKeyAlias" id="cdk-image-pipeline.ImagePipelineProps.property.kmsKeyAlias"></a>
+
+```typescript
+public readonly kmsKeyAlias: string;
+```
+
+- *Type:* string
+
+KMS Key used to encrypt the SNS topic.
+
+Enter an existing KMS Key Alias in your target account/region.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This construct creates the required infrastructure for an Image Pipeline:
 
 - An EC2 Image Builder recipe defines the base image to use as your starting point to create a new image, along with the set of components that you add to customize your image and verify that everything is working as expected.
 
-- Image Builder uses the AWS Task Orchestrator and Executor (AWSTOE) component management application to orchestrate complex workflows. AWSTOE components are based on YAML documents that define the scripts to customize or test your image
+- Image Builder uses the AWS Task Orchestrator and Executor (AWSTOE) component management application to orchestrate complex workflows. AWSTOE components are based on YAML documents that define the scripts to customize or test your image. This construct supports single or multiple components.
 
 - Image Builder image pipelines provide an automation framework for creating and maintaining custom AMIs and container images.
 
@@ -47,8 +47,10 @@ import { Construct } from 'constructs';
 // ...
 // Create a new image pipeline with the required properties
 new ImagePipeline(this, "MyImagePipeline", {
-    componentDocPath: 'path/to/component_doc.yml',
-    componentName: 'MyComponent',
+    componentDocuments: ['component_example.yml', 'component_example_2.yml'],
+    componentNames: ['Component', 'Component2'],
+    componentVersions: ['0.0.1', '0.1.0'],
+    kmsKeyAlias: 'alias/my-key',
     profileName: 'ImagePipelineInstanceProfile',
     infraConfigName: 'MyInfrastructureConfiguration',
     imageRecipe: 'MyImageRecipe',
@@ -93,8 +95,10 @@ const private_subnet = vpc.privateSubnets;
 
 
 new ImagePipeline(this, "MyImagePipeline", {
-    componentDocPath: 'path/to/component_doc.yml',
-    componentName: 'MyComponent',
+    componentDocuments: ['component_example.yml', 'component_example_2.yml'],
+    componentNames: ['Component', 'Component2'],
+    componentVersions: ['0.0.1', '0.1.0'],
+    kmsKeyAlias: 'alias/my-key',
     profileName: 'ImagePipelineInstanceProfile',
     infraConfigName: 'MyInfrastructureConfiguration',
     imageRecipe: 'MyImageRecipe',
@@ -115,14 +119,17 @@ from constructs import Construct
 image_pipeline = ImagePipeline(
     self,
     "LatestImagePipeline",
-    component_doc_path="component_example.yml",
-    component_name="Comp4",
+    component_documents=["component_example.yml", "component_example2.yml"],
+    component_names=["Component", "Component2"],
+    component_versions=["0.0.1", "0.1.0"],
+    kms_key_alias="alias/my-key",
     image_recipe="Recipe4",
     pipeline_name="Pipeline4",
     infra_config_name="InfraConfig4",
     parent_image="ami-0e1d30f2c40c4c701",
     profile_name="ImagePipelineProfile4",
 )
+# ...
 ```
 
 ```python
@@ -163,8 +170,10 @@ priv_subnets = vpc.private_subnets
 image_pipeline = ImagePipeline(
     self,
     "LatestImagePipeline",
-    component_doc_path="component_example.yml",
-    component_name="Comp4",
+    component_documents=["component_example.yml", "component_example2.yml"],
+    component_names=["Component", "Component2"],
+    component_versions=["0.0.1", "0.1.0"],
+    kms_key_alias="alias/my-key",
     image_recipe="Recipe4",
     pipeline_name="Pipeline4",
     infra_config_name="InfraConfig4",
@@ -173,6 +182,7 @@ image_pipeline = ImagePipeline(
     security_groups=[sg.security_group_id],
     subnet_id=priv_subnets[0].subnet_id
 )
+# ...
 ```
 
 ### Component Documents
@@ -208,6 +218,19 @@ phases:
           commands:
             - echo "Hello World! Test.
 ```
+
+### Multiple Components
+
+To specify multiple components, add additional component documents to the `componentDoucments` property. You can also add the names and versions of these components via the `componentNames` and `componentVersions` properties (_See usage examples above_). The components will be associated to the Image Recipe that gets created as part of the construct.
+
+Be sure to update the `imageRecipeVersion` property when making updates to your components after your initial deployment.
+
+### SNS Encryption using KMS
+
+---
+
+Specify an alias via the `kmsKeyAlias` property which will be used to encrypt the SNS topic.
+
 
 ### Infrastructure Configuration Instance Types
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This construct creates the required infrastructure for an Image Pipeline:
 
 - An EC2 Image Builder recipe defines the base image to use as your starting point to create a new image, along with the set of components that you add to customize your image and verify that everything is working as expected.
 
-- Image Builder uses the AWS Task Orchestrator and Executor (AWSTOE) component management application to orchestrate complex workflows. AWSTOE components are based on YAML documents that define the scripts to customize or test your image. This construct supports single or multiple components.
+- Image Builder uses the AWS Task Orchestrator and Executor (AWSTOE) component management application to orchestrate complex workflows. AWSTOE components are based on YAML documents that define the scripts to customize or test your image. Support for multiple components.
 
 - Image Builder image pipelines provide an automation framework for creating and maintaining custom AMIs and container images.
 
@@ -57,6 +57,7 @@ new ImagePipeline(this, "MyImagePipeline", {
     pipelineName: 'MyImagePipeline',
     parentImage: 'ami-0e1d30f2c40c4c701'
 })
+// ...
 ```
 
 By default, the infrastructure configuration will deploy EC2 instances for the build/test phases into a default VPC using the default security group. If you want to control where the instances are launched, you can specify an existing VPC `SubnetID` and a list of `SecurityGroupIds`. In the example below, a new VPC is created and referenced in the `ImagePipeline` construct object.
@@ -107,6 +108,7 @@ new ImagePipeline(this, "MyImagePipeline", {
     securityGroups: [sg.securityGroupId],
     subnetId: private_subnet[0].subnetId,
 })
+// ...
 ```
 
 Python usage:

--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ Be sure to update the `imageRecipeVersion` property when making updates to your 
 
 Specify an alias via the `kmsKeyAlias` property which will be used to encrypt the SNS topic.
 
-
 ### Infrastructure Configuration Instance Types
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,13 +125,6 @@ export class ImagePipeline extends Construct {
 
     infrastructureConfig.addDependsOn(profile);
 
-    // const component = new imagebuilder.CfnComponent(this, 'Component', {
-    //   name: props.componentName,
-    //   platform: props.platform ?? 'Linux',
-    //   version: '1.0.0',
-    //   data: readFileSync(props.componentDocPath).toString(),
-    // });
-
     const imageRecipe = new imagebuilder.CfnImageRecipe(this, 'ImageRecipe', {
       components: [],
       name: props.imageRecipe,
@@ -143,7 +136,7 @@ export class ImagePipeline extends Construct {
       let component = new imagebuilder.CfnComponent(this, props.componentNames[index], {
         name: props.componentNames[index],
         platform: props.platform ?? 'Linux',
-        version: props.componentVersions[index],
+        version: props.componentVersions[index] ?? '0.0.1',
         data: readFileSync(document).toString(),
       });
 

--- a/test/imagepipeline.test.ts
+++ b/test/imagepipeline.test.ts
@@ -5,8 +5,9 @@ import { ImagePipeline, ImagePipelineProps } from '../src';
 let template: Template;
 
 const props: ImagePipelineProps = {
-  componentDocPath: 'test/test_component_example.yml',
-  componentName: 'TestComponent',
+  componentDocuments: ['test/test_component_example.yml'],
+  componentNames: ['TestComponent'],
+  componentVersions: ['1.0.0'],
   profileName: 'TestProfile',
   infraConfigName: 'TestInfrastructureConfig',
   imageRecipe: 'TestImageRecipe',
@@ -17,8 +18,9 @@ const props: ImagePipelineProps = {
 };
 
 const propsWithNetworking: ImagePipelineProps = {
-  componentDocPath: 'test/test_component_example.yml',
-  componentName: 'TestComponent',
+  componentDocuments: ['test/test_component_example.yml'],
+  componentNames: ['TestComponent'],
+  componentVersions: ['1.0.0'],
   profileName: 'TestProfile',
   infraConfigName: 'TestInfrastructureConfig',
   imageRecipe: 'TestImageRecipe',

--- a/test/imagepipeline.test.ts
+++ b/test/imagepipeline.test.ts
@@ -5,8 +5,8 @@ import { ImagePipeline, ImagePipelineProps } from '../src';
 let template: Template;
 
 const props: ImagePipelineProps = {
-  componentDocuments: ['test/test_component_example.yml'],
-  componentNames: ['TestComponent'],
+  componentDocuments: ['test/test_component_example.yml', 'test/test_component_example_2.yml'],
+  componentNames: ['TestComponent', 'TestComponent2'],
   componentVersions: ['1.0.0'],
   profileName: 'TestProfile',
   infraConfigName: 'TestInfrastructureConfig',
@@ -67,7 +67,6 @@ test('Infrastructure Configuration IAM Role and Instance Profile are created', (
 });
 
 test('IAM Role contains necessary permission set', () => {
-  console.log(template.findResources);
   template.hasResourceProperties('AWS::IAM::Role',
     Match.anyValue());
 });
@@ -111,7 +110,7 @@ test.skip('Infrastructure Configuration DependsOn Instance Profile', () => {
 });
 
 test('Image Builder Component is created', () => {
-  template.resourceCountIs('AWS::ImageBuilder::Component', 1);
+  template.resourceCountIs('AWS::ImageBuilder::Component', props.componentDocuments.length);
 });
 
 test('Image Recipe is created', () => {

--- a/test/imagepipeline.test.ts
+++ b/test/imagepipeline.test.ts
@@ -32,6 +32,8 @@ const propsWithNetworking: ImagePipelineProps = {
 };
 
 beforeAll(() => {
+  process.env.CDK_DEFAULT_ACCOUNT = '123456789012';
+  process.env.CDK_DEFAULT_REGION = 'us-east-1';
   const app = new cdk.App();
   const testStack = new cdk.Stack(app, 'testStack', {
     env: {

--- a/test/test_component_example_2.yml
+++ b/test/test_component_example_2.yml
@@ -1,0 +1,28 @@
+name: ComponentExample
+description: This is an example component document
+schemaVersion: 1.0
+
+phases:
+  - name: build
+    steps:
+      - name: InstallUpdates
+        action: UpdateOS
+      - name: DownloadSomeShellScriptFromS3
+        action: S3Download
+        inputs:
+          - source: 's3://some-bucket/some_shell_script.sh'
+            destination: '/tmp/some_shell_script.sh'
+  - name: validate
+    steps:
+      - name: HelloWorldStep
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "Hello World! Validate."
+  - name: test
+    steps:
+      - name: HelloWorldStep
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "Hello World! Test.


### PR DESCRIPTION
# Features

- SNS topic encryption is now enforced via the use of KMS alias.
- Support for specifying multiple Image Builder Components.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.