### PR TITLE
chore(deps): bump minimist to latest

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -102,6 +102,10 @@
       "type": "build"
     },
     {
+      "name": "minimist",
+      "type": "bundled"
+    },
+    {
       "name": "aws-cdk-lib",
       "type": "peer"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -282,7 +282,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node @types/prettier @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema npm-check-updates standard-version ts-jest typescript aws-cdk-lib constructs"
+          "exec": "yarn upgrade @types/jest @types/node @types/prettier @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema npm-check-updates standard-version ts-jest typescript minimist aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -2,6 +2,7 @@ const { awscdk } = require('projen');
 const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Cameron Magee',
   authorAddress: 'magcamer@amazon.com',
+  bundledDeps: ['minimist'],
   copyrightOwner: 'Amazon.com, Inc. or its affiliates. All Rights Reserved.',
   cdkVersion: '2.59.0',
   constructsVersion: '10.1.215',

--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
     "aws-cdk-lib": "^2.59.0",
     "constructs": "^10.1.215"
   },
+  "dependencies": {
+    "minimist": "^1.2.7"
+  },
+  "bundledDependencies": [
+    "minimist"
+  ],
   "keywords": [
     "cdk"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,9 +4180,9 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@>=1.2.2, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+minimist@>=1.2.2, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.7:
   version "1.2.7"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minipass-collect@^1.0.2:


### PR DESCRIPTION
# Fixes
 
Bumps minimist to latest version to resolve security finding from dependabot
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.