### PR TITLE
Replace hard-coded platform attribute with previously-defined value in ImagePipelineProps allowing Windows images to be built with powershell component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ export class ImagePipeline extends Construct {
     props.components.forEach((component) => {
       let newComponent = new imagebuilder.CfnComponent(this, component.name, {
         name: component.name,
-        platform: 'Linux',
+        platform: props.platform ? props.platform : 'Linux',
         version: component.version,
         data: readFileSync(component.document).toString(),
       });


### PR DESCRIPTION
# Description

Fixed a bug where windows-based images cannot be built with windows component (powershell script). This is caused by the platform property in componentProps being hard-coded to Linux instead of checking previously defined value.

Tested the change locally and is now able to build successfully.
# Error
```
failed: Error: The stack named {REDUCTED} failed to deploy: UPDATE_ROLLBACK_COMPLETE: Resource handler returned message: "The value supplied for parameter 'data' is not valid. Parsing step 'DisableWindowsUpdate' in phase 'update' failed. Error: Unsupported action ExecutePowerShell for os platform linux. (Service: Imagebuilder, Status Code: 400, Request ID:{REDUCTED})" (RequestToken: {REDUCTED}, HandlerErrorCode: GeneralServiceException)
``` 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.