### PR TITLE
fix: convert kms key alias to ikey

### DIFF
--- a/API.md
+++ b/API.md
@@ -201,7 +201,6 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.components">components</a></code> | <code><a href="#cdk-image-pipeline.ComponentProps">ComponentProps</a>[]</code> | List of component props. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.imageRecipe">imageRecipe</a></code> | <code>string</code> | Name of the Image Recipe. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.infraConfigName">infraConfigName</a></code> | <code>string</code> | Name of the Infrastructure Configuration for Image Builder. |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.kmsKeyAlias">kmsKeyAlias</a></code> | <code>string</code> | KMS Key used to encrypt the SNS topic. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.parentImage">parentImage</a></code> | <code>string</code> | The source (parent) image that the image recipe uses as its base environment. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.pipelineName">pipelineName</a></code> | <code>string</code> | Name of the Image Pipeline. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.profileName">profileName</a></code> | <code>string</code> | Name of the instance profile that will be associated with the Instance Configuration. |
@@ -217,6 +216,7 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.enableVulnScans">enableVulnScans</a></code> | <code>boolean</code> | Set to true if you want to enable continuous vulnerability scans through AWS Inpector. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.imageRecipeVersion">imageRecipeVersion</a></code> | <code>string</code> | Image recipe version (Default: 0.0.1). |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.instanceTypes">instanceTypes</a></code> | <code>string[]</code> | List of instance types used in the Instance Configuration (Default: [ 't3.medium', 'm5.large', 'm5.xlarge' ]). |
+| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | KMS Key used to encrypt the SNS topic. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.platform">platform</a></code> | <code>string</code> | Platform type Linux or Windows (Default: Linux). |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.securityGroups">securityGroups</a></code> | <code>string[]</code> | List of security group IDs for the Infrastructure Configuration. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.subnetId">subnetId</a></code> | <code>string</code> | Subnet ID for the Infrastructure Configuration. |
@@ -259,20 +259,6 @@ public readonly infraConfigName: string;
 - *Type:* string
 
 Name of the Infrastructure Configuration for Image Builder.
-
----
-
-##### `kmsKeyAlias`<sup>Required</sup> <a name="kmsKeyAlias" id="cdk-image-pipeline.ImagePipelineProps.property.kmsKeyAlias"></a>
-
-```typescript
-public readonly kmsKeyAlias: string;
-```
-
-- *Type:* string
-
-KMS Key used to encrypt the SNS topic.
-
-Enter an existing KMS Key Alias in your target account/region.
 
 ---
 
@@ -455,6 +441,18 @@ public readonly instanceTypes: string[];
 - *Type:* string[]
 
 List of instance types used in the Instance Configuration (Default: [ 't3.medium', 'm5.large', 'm5.xlarge' ]).
+
+---
+
+##### `kmsKey`<sup>Optional</sup> <a name="kmsKey" id="cdk-image-pipeline.ImagePipelineProps.property.kmsKey"></a>
+
+```typescript
+public readonly kmsKey: IKey;
+```
+
+- *Type:* aws-cdk-lib.aws_kms.IKey
+
+KMS Key used to encrypt the SNS topic.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Be sure to update the `imageRecipeVersion` property when making updates to your 
 
 ---
 
-Specify an alias via the `kmsKeyAlias` property which will be used to encrypt the SNS topic.
+Specify a KMS Key via the `kmsKey` property which will be used to encrypt the SNS topic.
 
 ### Infrastructure Configuration Instance Types
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,9 @@ export interface ImagePipelineProps {
    */
   readonly parentImage: string;
   /**
-   * KMS Key used to encrypt the SNS topic. Enter an existing KMS Key Alias in your target account/region.
+   * KMS Key used to encrypt the SNS topic.
    */
-  readonly kmsKeyAlias: string;
+  readonly kmsKey?: kms.IKey;
   /**
    * List of instance types used in the Instance Configuration (Default: [ 't3.medium', 'm5.large', 'm5.xlarge' ])
    */
@@ -151,13 +151,9 @@ export class ImagePipeline extends Construct {
     this.imageRecipeComponents = [];
 
     // Construct code below
-    const kmsKey = kms.Key.fromLookup(this, 'KmsKeyLookup', {
-      aliasName: props.kmsKeyAlias,
-    });
-
     const topic = new sns.Topic(this, 'ImageBuilderTopic', {
       displayName: 'Image Builder Notify',
-      masterKey: kmsKey,
+      masterKey: props.kmsKey,
     });
 
     if (props.email != null) {

--- a/test/imagepipeline.test.ts
+++ b/test/imagepipeline.test.ts
@@ -22,7 +22,6 @@ const props: ImagePipelineProps = {
   imageRecipe: 'TestImageRecipe',
   pipelineName: 'TestImagePipeline',
   parentImage: 'ami-04505e74c0741db8d', // Ubuntu Server 20.04 LTS
-  kmsKeyAlias: 'alias/app1/key',
   email: 'unit@test.com',
   enableVulnScans: true,
   vulnScansRepoName: 'image-builder-vuln-scans',
@@ -45,7 +44,6 @@ const propsWithNetworking: ImagePipelineProps = {
   imageRecipe: 'TestImageRecipe',
   pipelineName: 'TestImagePipeline',
   parentImage: 'ami-04505e74c0741db8d', // Ubuntu Server 20.04 LTS
-  kmsKeyAlias: 'alias/app1/key',
   securityGroups: ['sg-12345678'],
   subnetId: 'subnet-12345678',
 };
@@ -63,7 +61,6 @@ const propsWithVolumeConfig: ImagePipelineProps = {
   imageRecipe: 'TestImageRecipe',
   pipelineName: 'TestImagePipeline',
   parentImage: 'ami-04505e74c0741db8d', // Ubuntu Server 20.04 LTS
-  kmsKeyAlias: 'alias/app1/key',
   securityGroups: ['sg-12345678'],
   subnetId: 'subnet-12345678',
   ebsVolumeConfigurations: [


### PR DESCRIPTION
# Fixes
 
- Converted KMS Key Alias lookup to use a standard IKey, removing the external lookup call
- Set the KMS Key to be optional, since it is not absolutely required to create an SNS Topic

Users can still use an Alias lookup prior to calling this construct, but it is no longer required.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Resolves #137 