### PR TITLE
feat!: dynamic naming and importing existing components

### DIFF
--- a/API.md
+++ b/API.md
@@ -198,12 +198,8 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.components">components</a></code> | <code><a href="#cdk-image-pipeline.ComponentProps">ComponentProps</a>[]</code> | List of component props. |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.imageRecipe">imageRecipe</a></code> | <code>string</code> | Name of the Image Recipe. |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.infraConfigName">infraConfigName</a></code> | <code>string</code> | Name of the Infrastructure Configuration for Image Builder. |
+| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.components">components</a></code> | <code>string \| <a href="#cdk-image-pipeline.ComponentProps">ComponentProps</a>[]</code> | List of component props. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.parentImage">parentImage</a></code> | <code>string</code> | The source (parent) image that the image recipe uses as its base environment. |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.pipelineName">pipelineName</a></code> | <code>string</code> | Name of the Image Pipeline. |
-| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.profileName">profileName</a></code> | <code>string</code> | Name of the instance profile that will be associated with the Instance Configuration. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.additionalPolicies">additionalPolicies</a></code> | <code>aws-cdk-lib.aws_iam.ManagedPolicy[]</code> | Additional policies to add to the instance profile associated with the Instance Configurations. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.amiIdSsmAccountId">amiIdSsmAccountId</a></code> | <code>string</code> | Account ID for Parameter Store path above. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.amiIdSsmPath">amiIdSsmPath</a></code> | <code>string</code> | Parameter Store path to store latest AMI ID under. |
@@ -229,36 +225,12 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 ##### `components`<sup>Required</sup> <a name="components" id="cdk-image-pipeline.ImagePipelineProps.property.components"></a>
 
 ```typescript
-public readonly components: ComponentProps[];
+public readonly components: string | ComponentProps[];
 ```
 
-- *Type:* <a href="#cdk-image-pipeline.ComponentProps">ComponentProps</a>[]
+- *Type:* string | <a href="#cdk-image-pipeline.ComponentProps">ComponentProps</a>[]
 
 List of component props.
-
----
-
-##### `imageRecipe`<sup>Required</sup> <a name="imageRecipe" id="cdk-image-pipeline.ImagePipelineProps.property.imageRecipe"></a>
-
-```typescript
-public readonly imageRecipe: string;
-```
-
-- *Type:* string
-
-Name of the Image Recipe.
-
----
-
-##### `infraConfigName`<sup>Required</sup> <a name="infraConfigName" id="cdk-image-pipeline.ImagePipelineProps.property.infraConfigName"></a>
-
-```typescript
-public readonly infraConfigName: string;
-```
-
-- *Type:* string
-
-Name of the Infrastructure Configuration for Image Builder.
 
 ---
 
@@ -273,30 +245,6 @@ public readonly parentImage: string;
 The source (parent) image that the image recipe uses as its base environment.
 
 The value can be the parent image ARN or an Image Builder AMI ID
-
----
-
-##### `pipelineName`<sup>Required</sup> <a name="pipelineName" id="cdk-image-pipeline.ImagePipelineProps.property.pipelineName"></a>
-
-```typescript
-public readonly pipelineName: string;
-```
-
-- *Type:* string
-
-Name of the Image Pipeline.
-
----
-
-##### `profileName`<sup>Required</sup> <a name="profileName" id="cdk-image-pipeline.ImagePipelineProps.property.profileName"></a>
-
-```typescript
-public readonly profileName: string;
-```
-
-- *Type:* string
-
-Name of the instance profile that will be associated with the Instance Configuration.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,6 @@ new ImagePipeline(this, "MyImagePipeline", {
         version: '0.1.0',
       },
     ],
-    kmsKeyAlias: 'alias/my-key',
-    profileName: 'ImagePipelineInstanceProfile',
-    infraConfigName: 'MyInfrastructureConfiguration',
-    imageRecipe: 'MyImageRecipe',
-    pipelineName: 'MyImagePipeline',
     parentImage: 'ami-0e1d30f2c40c4c701',
     ebsVolumeConfigurations: [
         {
@@ -130,11 +125,6 @@ new ImagePipeline(this, "MyImagePipeline", {
         version: '0.1.0',
       },
     ],
-    kmsKeyAlias: 'alias/my-key',
-    profileName: 'ImagePipelineInstanceProfile',
-    infraConfigName: 'MyInfrastructureConfiguration',
-    imageRecipe: 'MyImageRecipe',
-    pipelineName: 'MyImagePipeline',
     parentImage: 'ami-0e1d30f2c40c4c701',
     securityGroups: [sg.securityGroupId],
     subnetId: private_subnet[0].subnetId,
@@ -164,12 +154,7 @@ image_pipeline = ImagePipeline(
         version: '0.1.0',
       },
     ],
-    kms_key_alias="alias/my-key",
-    image_recipe="Recipe4",
-    pipeline_name="Pipeline4",
-    infra_config_name="InfraConfig4",
     parent_image="ami-0e1d30f2c40c4c701",
-    profile_name="ImagePipelineProfile4",
 )
 # ...
 ```
@@ -224,12 +209,7 @@ image_pipeline = ImagePipeline(
         version: '0.1.0',
       },
     ],
-    kms_key_alias="alias/my-key",
-    image_recipe="Recipe4",
-    pipeline_name="Pipeline4",
-    infra_config_name="InfraConfig4",
     parent_image="ami-0e1d30f2c40c4c701",
-    profile_name="ImagePipelineProfile4",
     security_groups=[sg.security_group_id],
     subnet_id=priv_subnets[0].subnet_id
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,9 +329,19 @@ export class ImagePipeline extends Construct {
     new imagebuilder.CfnImagePipeline(this, 'ImagePipeline', imagePipelineProps);
   }
 
+  /**
+   * Helper function to hash an object to create unique resource names
+   * 
+   * @param o an object to hash
+   * @returns 6 character hash string
+   */
   private hash(o: object): string {
+    // Remove any token references that would cause the result to be
+    // non-deterministic.
+    const cleanString = JSON.stringify(o).replace(/\${[^{]*}/g, '');
+
     return createHash('sha256')
-      .update(JSON.stringify(o))
+      .update(cleanString)
       .digest('hex')
       .toUpperCase()
       .slice(0, 6);

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,7 +331,7 @@ export class ImagePipeline extends Construct {
 
   /**
    * Helper function to hash an object to create unique resource names
-   * 
+   *
    * @param o an object to hash
    * @returns 6 character hash string
    */

--- a/test/imagepipeline.test.ts
+++ b/test/imagepipeline.test.ts
@@ -17,10 +17,6 @@ const props: ImagePipelineProps = {
       version: '1.0.0',
     },
   ],
-  profileName: 'TestProfile',
-  infraConfigName: 'TestInfrastructureConfig',
-  imageRecipe: 'TestImageRecipe',
-  pipelineName: 'TestImagePipeline',
   parentImage: 'ami-04505e74c0741db8d', // Ubuntu Server 20.04 LTS
   email: 'unit@test.com',
   enableVulnScans: true,
@@ -39,10 +35,6 @@ const propsWithNetworking: ImagePipelineProps = {
       version: '1.0.0',
     },
   ],
-  profileName: 'TestProfile',
-  infraConfigName: 'TestInfrastructureConfig',
-  imageRecipe: 'TestImageRecipe',
-  pipelineName: 'TestImagePipeline',
   parentImage: 'ami-04505e74c0741db8d', // Ubuntu Server 20.04 LTS
   securityGroups: ['sg-12345678'],
   subnetId: 'subnet-12345678',
@@ -56,10 +48,6 @@ const propsWithVolumeConfig: ImagePipelineProps = {
       version: '1.0.0',
     },
   ],
-  profileName: 'TestProfile',
-  infraConfigName: 'TestInfrastructureConfig',
-  imageRecipe: 'TestImageRecipe',
-  pipelineName: 'TestImagePipeline',
   parentImage: 'ami-04505e74c0741db8d', // Ubuntu Server 20.04 LTS
   securityGroups: ['sg-12345678'],
   subnetId: 'subnet-12345678',
@@ -144,8 +132,6 @@ test('Infrastructure Configuration is built with provided Networking properties'
   const templateWithNetworking = Template.fromStack(testStack);
 
   templateWithNetworking.hasResourceProperties('AWS::ImageBuilder::InfrastructureConfiguration', {
-    InstanceProfileName: props.profileName,
-    Name: props.infraConfigName,
     SnsTopicArn: Match.anyValue(),
     SecurityGroupIds: ['sg-12345678'],
     SubnetId: 'subnet-12345678',
@@ -164,7 +150,6 @@ test('Infrastructure Configuration is built with provided EBS volume properties'
   const templateWithVolume = Template.fromStack(testStack);
 
   templateWithVolume.hasResourceProperties('AWS::ImageBuilder::ImageRecipe', {
-    Name: 'TestImageRecipe',
     BlockDeviceMappings: [
       {
         DeviceName: '/dev/xvda',
@@ -180,20 +165,14 @@ test('Infrastructure Configuration is built with provided EBS volume properties'
     ],
   });
   templateWithVolume.hasResourceProperties('AWS::ImageBuilder::InfrastructureConfiguration', {
-    InstanceProfileName: props.profileName,
-    Name: props.infraConfigName,
     SnsTopicArn: Match.anyValue(),
     SecurityGroupIds: ['sg-12345678'],
     SubnetId: 'subnet-12345678',
   });
   templateWithVolume.hasResourceProperties('AWS::ImageBuilder::DistributionConfiguration', {
-    Name: 'TestImageRecipe-distribution-config',
-    Description: 'Cross account distribution settings for TestImageRecipe',
     Distributions: [{
       Region: 'us-east-1',
       AmiDistributionConfiguration: {
-        Name: 'TestImageRecipe-us-east-1-{{imagebuilder:buildDate}}',
-        Description: 'copy AMI TestImageRecipe to us-east-1',
         TargetAccountIds: ['111222333444'],
         LaunchPermissionConfiguration: {
           UserIds: ['111222333444'],
@@ -207,8 +186,6 @@ test('Infrastructure Configuration is built with provided EBS volume properties'
 
 test('Infrastructure Configuration contains required properties', () => {
   template.hasResourceProperties('AWS::ImageBuilder::InfrastructureConfiguration', {
-    InstanceProfileName: props.profileName,
-    Name: props.infraConfigName,
     SnsTopicArn: Match.anyValue(),
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2508,7 +2508,7 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
 
 glob@^8:
   version "8.1.0"
-  resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
@@ -2737,7 +2737,7 @@ ini@^1.3.2:
 
 ini@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 internal-slot@^1.0.7:


### PR DESCRIPTION
# Fixes
 
- Changed hardcoded names to be generated instead of supplied by the user
- Dynamically determine the RecipeName based hashing the supplied components. This will make it so the user can modify the components and redeploy without failing in CloudFormation (since we are no longer deploying using the same name)
- Removed props that reference hardcoded names
- Add capability to import existing component by supplying the `arn` of the component instead of a ComponentProp

 Resolves #132 

Example construct creation:

![image](https://github.com/aws-samples/cdk-image-pipeline/assets/26290287/c9fc16c3-60bf-408e-b7de-9704b278a9c2)

Name props are gone, and also showcasing the ability to import an existing component by ARN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.