### PR TITLE
fix: Allow usage of fully qualified ssm parameter names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -291,10 +291,11 @@ export class ImagePipeline extends Construct {
      * (only if a Parameter Store path is provided)
      */
     if (props.amiIdSsmPath) {
+      const amiIdSsmPath = props.amiIdSsmPath.replace(/^\/+/, '/');
       const amiSsmUpdateLambdaPolicy = new iam.PolicyDocument({
         statements: [
           new iam.PolicyStatement({
-            resources: [`arn:aws:ssm:${props.amiIdSsmRegion}:${props.amiIdSsmAccountId}:parameter/${props.amiIdSsmPath}`],
+            resources: [`arn:aws:ssm:${props.amiIdSsmRegion}:${props.amiIdSsmAccountId}:parameter${amiIdSsmPath}`],
             actions: [
               'ssm:PutParameter',
               'ssm:GetParameterHistory',
@@ -320,7 +321,7 @@ export class ImagePipeline extends Construct {
         handler: 'image-builder-lambda-update-ssm.lambda_handler',
         role: amiSsmUpdateLambdaRole,
         environment: {
-          SSM_PATH: props.amiIdSsmPath,
+          SSM_PATH: amiIdSsmPath,
         },
         memorySize: 256,
       });

--- a/test/imagepipeline.test.ts
+++ b/test/imagepipeline.test.ts
@@ -109,8 +109,29 @@ test('Infrastructure Configuration IAM Role and Instance Profile are created', (
 });
 
 test('IAM Role contains necessary permission set', () => {
-  template.hasResourceProperties('AWS::IAM::Role',
-    Match.anyValue());
+  template.hasResourceProperties('AWS::IAM::Role', {
+    Policies: [
+      {
+        PolicyName: 'AmiSsmUpdateLambdaPolicy',
+        PolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: [
+                'ssm:PutParameter',
+                'ssm:GetParameterHistory',
+                'ssm:GetParameter',
+                'ssm:GetParameters',
+                'ssm:AddTagsToResource',
+              ],
+              Resource: 'arn:aws:ssm:us-east-1:11223344556:parameter/ec2-image-builder/al2-x86',
+            },
+          ],
+        },
+      },
+    ],
+  });
+
 });
 
 test('Infrastructure Configuration has the default instance types', () => {


### PR DESCRIPTION
# Fixes #148
 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.