### PR TITLE
feat: expose components as properties

### DIFF
--- a/API.md
+++ b/API.md
@@ -99,6 +99,8 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-image-pipeline.ImagePipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#cdk-image-pipeline.ImagePipeline.property.builderSnsTopic">builderSnsTopic</a></code> | <code>aws-cdk-lib.aws_sns.Topic</code> | SNS Topic where the internal ImageBuilder will notify about new builds. |
+| <code><a href="#cdk-image-pipeline.ImagePipeline.property.pipeline">pipeline</a></code> | <code>aws-cdk-lib.aws_imagebuilder.CfnImagePipeline</code> | The internal image pipeline created by this construct. |
 | <code><a href="#cdk-image-pipeline.ImagePipeline.property.imageRecipeComponents">imageRecipeComponents</a></code> | <code>aws-cdk-lib.aws_imagebuilder.CfnImageRecipe.ComponentConfigurationProperty[]</code> | *No description.* |
 
 ---
@@ -112,6 +114,30 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `builderSnsTopic`<sup>Required</sup> <a name="builderSnsTopic" id="cdk-image-pipeline.ImagePipeline.property.builderSnsTopic"></a>
+
+```typescript
+public readonly builderSnsTopic: Topic;
+```
+
+- *Type:* aws-cdk-lib.aws_sns.Topic
+
+SNS Topic where the internal ImageBuilder will notify about new builds.
+
+---
+
+##### `pipeline`<sup>Required</sup> <a name="pipeline" id="cdk-image-pipeline.ImagePipeline.property.pipeline"></a>
+
+```typescript
+public readonly pipeline: CfnImagePipeline;
+```
+
+- *Type:* aws-cdk-lib.aws_imagebuilder.CfnImagePipeline
+
+The internal image pipeline created by this construct.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ from aws_cdk import (
     Stack,
     aws_ec2 as ec2,
 )
-from consturcts import Construct
+from constructs import Construct
 from cdk_image_pipeline import ImagePipeline
 
 # ...

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,13 @@ export interface ImagePipelineProps {
 
 export class ImagePipeline extends Construct {
   imageRecipeComponents: imagebuilder.CfnImageRecipe.ComponentConfigurationProperty[];
+  /**
+   * The internal image pipeline created by this construct.
+   */
   readonly pipeline: imagebuilder.CfnImagePipeline;
+  /**
+   * SNS Topic where the internal ImageBuilder will notify about new builds.
+   */
   readonly builderSnsTopic: sns.Topic;
 
   constructor(scope: Construct, id: string, props: ImagePipelineProps) {

--- a/test/imagepipeline.test.ts
+++ b/test/imagepipeline.test.ts
@@ -237,3 +237,17 @@ test('Image Pipeline has Inspector vulnerability scans configured', () => {
     },
   });
 });
+
+
+test('ImagePipeline exposes components as properties', () => {
+  const app = new cdk.App();
+  const testStack = new cdk.Stack(app, 'testStack', {
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION,
+    },
+  });
+  const sut = new ImagePipeline(testStack, 'ImagePipelineStack', props);
+  expect(sut.pipeline).toBeDefined();
+  expect(sut.builderSnsTopic).toBeDefined();
+});


### PR DESCRIPTION
# Adds components
This PR exposes the `aws_imagebuilder.CfnImagePipeline` and the `aws_sns.Topic` as properties on the `ImagePipeline` construct.

This would allow more stable access to the internal components and the example from #157 could be changed like this:

```diff
-- const pipeline = new ImagePipeline(this, `${this.stackName}Image`, {
++ const imagePipeline = new ImagePipeline(this, `${this.stackName}Image`, {
  parentImage: `arn:aws:imagebuilder:${this.region}:aws:image/amazon-linux-2023-x86/x.x.x`,
})

// add a schedule to (re-)build the AMI on available dependency updates
-- const cfnImagePipeline = pipeline.node.findChild('ImagePipeline') as cdk.aws_imagebuilder.CfnImagePipeline
-- cfnImagePipeline.schedule = {
++ imagePipeline.pipeline.schedule = {
  pipelineExecutionStartCondition: 'EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE',
  scheduleExpression: 'cron(30 0 * * ? *)',
}
```
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.