### PR TITLE
feat: expose resourceTags property in CfnInfrastructureConfiguration class

### DIFF
--- a/API.md
+++ b/API.md
@@ -240,6 +240,7 @@ const imagePipelineProps: ImagePipelineProps = { ... }
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.instanceTypes">instanceTypes</a></code> | <code>string[]</code> | List of instance types used in the Instance Configuration (Default: [ 't3.medium', 'm5.large', 'm5.xlarge' ]). |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.kmsKey">kmsKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | KMS Key used to encrypt the SNS topic. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.platform">platform</a></code> | <code>string</code> | Platform type Linux or Windows (Default: Linux). |
+| <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.resourceTags">resourceTags</a></code> | <code>{[ key: string ]: any}</code> | The tags attached to the resource created by Image Builder. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.securityGroups">securityGroups</a></code> | <code>string[]</code> | List of security group IDs for the Infrastructure Configuration. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.subnetId">subnetId</a></code> | <code>string</code> | Subnet ID for the Infrastructure Configuration. |
 | <code><a href="#cdk-image-pipeline.ImagePipelineProps.property.userDataScript">userDataScript</a></code> | <code>string</code> | UserData script that will override default one (if specified). |
@@ -439,6 +440,18 @@ public readonly platform: string;
 - *Type:* string
 
 Platform type Linux or Windows (Default: Linux).
+
+---
+
+##### `resourceTags`<sup>Optional</sup> <a name="resourceTags" id="cdk-image-pipeline.ImagePipelineProps.property.resourceTags"></a>
+
+```typescript
+public readonly resourceTags: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+
+The tags attached to the resource created by Image Builder.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,10 @@ export interface ImagePipelineProps {
    * Region for Parameter Store path above
    */
   readonly amiIdSsmRegion?: string;
+  /**
+   * The tags attached to the resource created by Image Builder
+   */
+  readonly resourceTags?: {[key: string]: any};
 }
 
 export class ImagePipeline extends Construct {
@@ -181,6 +185,7 @@ export class ImagePipeline extends Construct {
         instanceProfileName: profileName,
         name: `${uid}InfraConfig`,
         description: 'Example Infrastructure Configuration for Image Builder',
+        resourceTags: props.resourceTags,
         instanceTypes: props.instanceTypes ?? ['t3.medium', 'm5.large', 'm5.xlarge'],
         snsTopicArn: this.builderSnsTopic.topicArn,
       });
@@ -189,6 +194,7 @@ export class ImagePipeline extends Construct {
         instanceProfileName: profileName,
         name: `${uid}InfraConfig`,
         description: 'Example Infrastructure Configuration for Image Builder',
+        resourceTags: props.resourceTags,
         instanceTypes: props.instanceTypes ?? ['t3.medium', 'm5.large', 'm5.xlarge'],
         snsTopicArn: this.builderSnsTopic.topicArn,
         securityGroupIds: props.securityGroups,


### PR DESCRIPTION
# Fixes
 
This PR exposes the `resourceTags` property in the [CfnInfrastructureConfiguration class](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_imagebuilder.CfnInfrastructureConfiguration.html#class-cfninfrastructureconfiguration-construct).  The `resourceTags` property are the tags attached to the resource created by Image Builder.

Issue: #192 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.